### PR TITLE
Use arrays for data stats in settings

### DIFF
--- a/src/components/settings/Settings.js
+++ b/src/components/settings/Settings.js
@@ -16,11 +16,13 @@ import { useData } from '../../contexts/DataContext';
 import { useAuth } from '../../contexts/AuthContext';
 
 const Settings = () => {
-  const { 
-    exportData, 
-    clearAllData, 
+  const {
+    exportData,
+    clearAllData,
     showNotification,
-    analytics 
+    transactions,
+    savings,
+    debts
   } = useData();
   const { user, logout } = useAuth();
   const [isExporting, setIsExporting] = useState(false);
@@ -69,9 +71,9 @@ const Settings = () => {
 
   const getDataStats = () => {
     return {
-      transactions: analytics.recentActivity.filter(item => item.type).length,
-      savings: analytics.recentActivity.filter(item => item.targetAmount).length,
-      debts: analytics.recentActivity.filter(item => item.interestRate !== undefined).length,
+      transactions: transactions.length,
+      savings: savings.length,
+      debts: debts.length,
       totalSize: '~2.5 MB' // Placeholder
     };
   };


### PR DESCRIPTION
## Summary
- expose transactions, savings, and debts from useData in Settings
- count items directly from these arrays instead of analytics.recentActivity

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6890a70a09548329b9c9aad1eb179579