### PR TITLE
Handle Firebase auth errors with friendly messages

### DIFF
--- a/src/contexts/AuthContext.js
+++ b/src/contexts/AuthContext.js
@@ -9,6 +9,7 @@ import {
 } from 'firebase/auth';
 import { auth, googleProvider } from '../firebase/config';
 import toast from 'react-hot-toast';
+import mapError from '../utils/mapError';
 
 const AuthContext = createContext();
 
@@ -39,7 +40,8 @@ export const AuthProvider = ({ children }) => {
       toast.success('Successfully logged in!');
       return result;
     } catch (error) {
-      toast.error(error.message);
+      console.error(error);
+      toast.error(mapError(error));
       throw error;
     }
   };
@@ -50,7 +52,8 @@ export const AuthProvider = ({ children }) => {
       toast.success('Account created successfully!');
       return result;
     } catch (error) {
-      toast.error(error.message);
+      console.error(error);
+      toast.error(mapError(error));
       throw error;
     }
   };
@@ -61,7 +64,8 @@ export const AuthProvider = ({ children }) => {
       toast.success('Successfully logged in with Google!');
       return result;
     } catch (error) {
-      toast.error(error.message);
+      console.error(error);
+      toast.error(mapError(error));
       throw error;
     }
   };
@@ -71,7 +75,8 @@ export const AuthProvider = ({ children }) => {
       await signOut(auth);
       toast.success('Successfully logged out!');
     } catch (error) {
-      toast.error(error.message);
+      console.error(error);
+      toast.error(mapError(error));
       throw error;
     }
   };
@@ -81,7 +86,8 @@ export const AuthProvider = ({ children }) => {
       await sendPasswordResetEmail(auth, email);
       toast.success('Password reset email sent!');
     } catch (error) {
-      toast.error(error.message);
+      console.error(error);
+      toast.error(mapError(error));
       throw error;
     }
   };

--- a/src/utils/mapError.js
+++ b/src/utils/mapError.js
@@ -1,0 +1,15 @@
+const ERROR_MESSAGES = {
+  'auth/user-not-found': 'No user found with this email.',
+  'auth/wrong-password': 'Incorrect password.',
+  'auth/email-already-in-use': 'Email is already in use.',
+  'auth/weak-password': 'Password should be at least 6 characters.',
+  'auth/invalid-email': 'Invalid email address.',
+  'auth/too-many-requests': 'Too many requests. Please try again later.',
+};
+
+export default function mapError(error) {
+  if (!error) {
+    return 'An unexpected error occurred. Please try again.';
+  }
+  return ERROR_MESSAGES[error.code] || 'An unexpected error occurred. Please try again.';
+}


### PR DESCRIPTION
## Summary
- add helper to map Firebase Auth error codes to readable messages
- use mapError in AuthContext and log original errors

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6890a71de784832983795f1349fb7d3d