### PR TITLE
Use explicit date for transaction creation time

### DIFF
--- a/src/components/dashboard/AIInsights.js
+++ b/src/components/dashboard/AIInsights.js
@@ -96,7 +96,7 @@ const AIInsights = () => {
     // Monthly comparison
     const currentMonth = new Date().getMonth();
     const lastMonthTransactions = transactions.filter(t => {
-      const date = new Date(t.createdAt);
+      const date = t.createdAt?.toDate ? t.createdAt.toDate() : new Date(t.createdAt);
       return date.getMonth() === currentMonth - 1;
     });
     

--- a/src/components/dashboard/ExpenseChart.js
+++ b/src/components/dashboard/ExpenseChart.js
@@ -4,7 +4,7 @@ import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContai
 const ExpenseChart = ({ transactions }) => {
   // Group transactions by month
   const monthlyData = transactions.reduce((acc, transaction) => {
-    const date = new Date(transaction.createdAt);
+    const date = transaction.createdAt?.toDate ? transaction.createdAt.toDate() : new Date(transaction.createdAt);
     const monthYear = date.toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
     
     if (!acc[monthYear]) {

--- a/src/components/transactions/AddTransactionModal.js
+++ b/src/components/transactions/AddTransactionModal.js
@@ -56,7 +56,6 @@ const AddTransactionModal = ({ isOpen, onClose, categories }) => {
         ...formData,
         amount: parseFloat(formData.amount),
         tags,
-        createdAt: new Date(formData.date).toISOString(),
         receiptUrl: receiptFile ? await uploadReceipt(receiptFile) : null
       };
 

--- a/src/components/transactions/Transactions.js
+++ b/src/components/transactions/Transactions.js
@@ -26,6 +26,8 @@ const Transactions = () => {
     'Salary', 'Freelance', 'Investment', 'Other'
   ];
 
+  const getDate = (item) => item.createdAt?.toDate ? item.createdAt.toDate() : new Date(item.createdAt);
+
   const filteredTransactions = transactions
     .filter(transaction => {
       const matchesSearch = transaction.description.toLowerCase().includes(searchTerm.toLowerCase()) ||
@@ -36,7 +38,7 @@ const Transactions = () => {
     .sort((a, b) => {
       switch (sortBy) {
         case 'date':
-          return new Date(b.createdAt) - new Date(a.createdAt);
+          return getDate(b) - getDate(a);
         case 'amount':
           return parseFloat(b.amount) - parseFloat(a.amount);
         case 'category':
@@ -56,8 +58,9 @@ const Transactions = () => {
     }
   };
 
-  const formatDate = (dateString) => {
-    return new Date(dateString).toLocaleDateString('en-US', {
+  const formatDate = (date) => {
+    const d = date?.toDate ? date.toDate() : new Date(date);
+    return d.toLocaleDateString('en-US', {
       year: 'numeric',
       month: 'short',
       day: 'numeric'


### PR DESCRIPTION
## Summary
- accept a `date` in `addTransaction` and convert it to a Firestore `Timestamp`
- send `date` from `AddTransactionModal` instead of `createdAt`
- normalize `createdAt` timestamps when sorting and charting transactions

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6890a70802888329a9b1b6f59aebb093